### PR TITLE
コミットを one-by-one で push できるスクリプトを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ notebook:
 
 notebook-check:
 	python colab/notebook.py | diff colab/websocket_server.ipynb -
+
+one-by-one-push:
+	python one_by_one_push.py

--- a/README.md
+++ b/README.md
@@ -174,3 +174,7 @@ Google Colaboratory に生成されたファイルをアップロードすれば
 Format: `make black`
 
 Lint: `make pyflakes`
+
+## （開発者向け）one-by-one push
+
+`make one-by-one-push`

--- a/one_by_one_push.py
+++ b/one_by_one_push.py
@@ -1,0 +1,35 @@
+import subprocess
+
+remote_show = subprocess.run(
+    "git remote show origin", shell=True, capture_output=True, text=True
+).stdout.strip("/n")
+head_branch_line = next(
+    line for line in remote_show.split("\n") if "HEAD branch" in line
+)
+head_branch = head_branch_line.split()[-1]
+
+current_branch = subprocess.run(
+    "git rev-parse --abbrev-ref HEAD", shell=True, capture_output=True, text=True
+).stdout.strip("\n")
+
+rev_list = subprocess.run(
+    f"git rev-list --reverse origin/{head_branch}..HEAD".format(
+        head_branch=head_branch
+    ),
+    shell=True,
+    capture_output=True,
+    text=True,
+).stdout.strip("\n")
+
+for rev in rev_list.split("\n"):
+    print(
+        f"git push origin {rev}:{current_branch} --force-with-lease".format(
+            rev=rev, current_branch=current_branch
+        )
+    )
+    subprocess.run(
+        f"git push origin {rev}:{current_branch} --force-with-lease".format(
+            rev=rev, current_branch=current_branch
+        ),
+        shell=True,
+    )


### PR DESCRIPTION
CI が各コミットで成功しているか確認するために，コミットを one-by-one で push できるスクリプトを追加する