### PR TITLE
[colab] Fix module dependencies for colab env

### DIFF
--- a/colab/notebook.py
+++ b/colab/notebook.py
@@ -16,8 +16,11 @@ fragments[
 !apt-get install libnvidia-gl-$(grep -oP 'NVIDIA UNIX x86_64 Kernel Module\s+\K[\d.]+(?=\s+)' /proc/driver/nvidia/version | grep -oE '^[0-9]+')
 """
 
-fragments["write_requirements.txt"] = "%%file requirements.txt\n" + re.sub(
-    "==.*", "", open("requirements.txt", encoding="utf-8").read()
+fragments["write_requirements.txt"] = "%%file requirements.txt\n" + "".join(
+    [
+        re.sub("==.*", "", line) if not "gl" in line else line
+        for line in open("requirements.txt", encoding="utf-8").readlines()
+    ]
 )
 
 fragments[

--- a/colab/websocket_server.ipynb
+++ b/colab/websocket_server.ipynb
@@ -19,8 +19,8 @@
    "outputs": [],
    "source": [
     "%%file requirements.txt\n",
-    "glcontext\n",
-    "moderngl\n",
+    "glcontext==2.4.0\n",
+    "moderngl==5.8.2\n",
     "numpy\n",
     "opencv-python\n",
     "websockets\n"


### PR DESCRIPTION
Colab で numpy のバージョン指定をすると
他のモジュールと競合を起こすことがあるので
すべての追加モジュールのバージョン指定を廃止していた．
しかし，moderngl 5.9.0 がインストールされると
`python -m moderngl`
が失敗する問題が見つかった．
これを回避するために，moderngl と glcontext のみ
バージョンを指定する．